### PR TITLE
added keras2json converter for Keras version 1.0.0

### DIFF
--- a/converters/keras1-0-0_2json.py
+++ b/converters/keras1-0-0_2json.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+#
+# Converter from Keras (version 1.0.0) saved NN to JSON
+"""
+____________________________________________________________________
+Variable specification file
+
+In additon to the standard Keras architecture and weights files, you
+must provide a "variable specification" json file with the following
+format:
+
+  {
+    "inputs": [
+      {"name": variable_name,
+       "scale": scale,
+       "offset": offset,
+       "default": default_value},
+      ...
+      ],
+    "class_labels": [output_class_1_name, output_class_2_name, ...],
+    "Keras version": "1.0.0"
+  }
+
+where `scale` and `offset` account for any scaling and shifting to the
+input variables in preprocessing. The "default" value is optional.
+
+"""
+
+import argparse
+import json
+import h5py
+import numpy as np
+
+def _run():
+    """Top level routine"""
+    args = _get_args()
+    with open(args.arch_file, 'r') as arch_file:
+        arch = json.load(arch_file)
+    with open(args.variables_file, 'r') as inputs_file:
+        inputs = json.load(inputs_file)
+
+    if  inputs.get('Keras version')!="1.0.0":
+        print("WARNING: This converter was developed for Keras version 1.0.0. \
+        The provided files were generated using version {} and therefore \
+        the conversion might break.".format(inputs.get('Keras version')))
+
+    with h5py.File(args.hdf5_file, 'r') as h5:
+        out_dict = {
+            'layers': _get_layers(arch, inputs, h5),
+        }
+        out_dict.update(_parse_inputs(inputs))
+    print(json.dumps(out_dict, indent=2))
+
+def _get_args():
+    parser = argparse.ArgumentParser(
+        description="Converter from Keras saved NN to JSON",
+        epilog=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument('arch_file', help='architecture json file')
+    parser.add_argument('variables_file', help='variable spec as json')
+    parser.add_argument('hdf5_file', help='Keras weights file')
+    return parser.parse_args()
+
+_activation_map = {
+    'relu': 'rectified',
+    'sigmoid': 'sigmoid',
+    None: 'linear',
+    # TODO: pass through unknown types rather than defining them as
+    # themselves?
+    'linear': 'linear',
+    'softmax': 'softmax',
+    'tanh': 'tanh',
+}
+
+# __________________________________________________________________________
+# Layer converters
+#
+# Each of these converters takes two arguments:
+#  - An H5 Group with the layer parameters
+#  - The number of inputs (for error checking)
+#
+# Each returns two outputs:
+#  - A dictionary of layer information which can be serialized to JSON
+#  - The number of outputs (also for error checking)
+
+def _get_dense_layer_parameters(layer_group, n_in):
+    """Get weights, bias, and n-outputs for a dense layer"""
+    weights = layer_group.get(list(layer_group.keys())[0])
+    bias = layer_group.get(list(layer_group.keys())[1])
+    assert weights.shape[1] == bias.shape[0]
+    assert weights.shape[0] == n_in
+    # TODO: confirm that we should be transposing the weight
+    # matrix the Keras case
+    return_dict = {
+        'weights': np.asarray(weights).T.flatten('C').tolist(),
+        'bias': np.asarray(bias).flatten('C').tolist(),
+        'architecture': 'dense'
+    }
+    return return_dict, weights.shape[1]
+
+
+def _get_maxout_layer_parameters(layer_group, n_in):
+    """Get weights, bias, and n-outputs for a maxout layer"""
+    weights = np.asarray(layer_group.get(list(layer_group.keys())[0]))
+    bias = np.asarray(layer_group.get(list(layer_group.keys())[1]))
+
+    # checks (note the transposed arrays)
+    wt_layers, wt_in, wt_out = weights.shape
+    bias_layers, bias_n = bias.shape
+    assert wt_out == bias_n
+    assert wt_in == n_in, '{} != {}'.format(wt_in, n_in)
+    assert wt_layers == bias_layers
+
+    sublayers = []
+    for nnn in range(weights.shape[0]):
+        w_slice = weights[nnn,:,:]
+        b_slice = bias[nnn,:]
+        sublayer = {
+            'weights': w_slice.T.flatten().tolist(),
+            'bias': b_slice.flatten().tolist(),
+            'architecture': 'dense'
+        }
+        sublayers.append(sublayer)
+    return {'sublayers': sublayers, 'architecture': 'maxout'}, wt_out
+
+def _dummy_parameters(layer_group, n_in):
+    """Return dummy parameters"""
+    return {'weights':[], 'bias':[], 'architecture':'dense'}, n_in
+
+_layer_converters = {
+    'dense': _get_dense_layer_parameters,
+    'maxoutdense': _get_maxout_layer_parameters,
+    'activation': _dummy_parameters,
+    'flatten': _dummy_parameters,
+    }
+
+# __________________________________________________________________________
+# master layer converter / inputs function
+
+def _get_layers(network, inputs, h5):
+    layers = []
+    in_layers = network['config']
+    n_out = len(inputs['inputs'])
+    for layer_n in range(len(in_layers)):
+        # get converter for this layer
+        layer_arch = in_layers[layer_n]
+        layer_type = layer_arch['class_name'].lower()
+        convert = _layer_converters[layer_type]
+
+        # get the hdf5 info
+        layer_group = h5['{0}_{1}'.format(layer_type, layer_n+1)]
+
+        # build the out layer
+        out_layer, n_out = convert(layer_group, n_out)
+        out_layer['activation'] = _activation_map[
+            layer_arch.get('config').get('activation')]
+        layers.append(out_layer)
+    return layers
+
+def _parse_inputs(keras_dict):
+    inputs = []
+    defaults = {}
+    for val in keras_dict['inputs']:
+        inputs.append({x: val[x] for x in ['offset', 'scale', 'name']})
+
+        # maybe fill default
+        default = val.get("default")
+        if default is not None:
+            defaults[val['name']] = default
+    return {
+        'inputs': inputs,
+        'outputs': keras_dict['class_labels'],
+        'defaults': defaults,
+    }
+
+if __name__ == '__main__':
+    _run()

--- a/converters/variables_ntuple2athena.py
+++ b/converters/variables_ntuple2athena.py
@@ -32,7 +32,7 @@ def _get_args():
     return parser.parse_args()
 
 _variable_convention_converter = {
-    'eta_abs_uCalib': 'jet_eta',
+    'eta_abs_uCalib': 'jet_abs_eta',
     'pt_uCalib': 'jet_pt',
     'jf_mass': 'jf_m',
     'jf_mass_check': 'jf_m_check',

--- a/converters/variables_ntuple2athena.py
+++ b/converters/variables_ntuple2athena.py
@@ -48,12 +48,19 @@ _variable_convention_converter = {
     'sv1_sig3': 'sv1_sig3d',
     }
 
+_output_labeling_convention_converter = {
+    'b-jet': 'bottom',
+    'c-jet': 'charm',
+    'u-jet': 'light'
+}
+
 def _update_naming_convention(network):
     """Update naming convention from the one used during training to the one used in Athena"""
-    input_variable_list = _get_input_variables(network)
+    input_variables_list = _get_input_variables(network)
+    output_variables_list = _get_output_variables(network)
 
     # replace 'default' key string with the one used in Athena:
-    for variable_name in input_variable_list:
+    for variable_name in input_variables_list:
         if variable_name in list(network['defaults'].keys()):
             if variable_name in list(_variable_convention_converter.keys()):
                 network['defaults'][_variable_convention_converter.get(variable_name)] = network['defaults'].get(variable_name)
@@ -63,6 +70,12 @@ def _update_naming_convention(network):
     for variable_itr, variable_item in enumerate(network.get('inputs')):
         if variable_item.get('name') in list(_variable_convention_converter.keys()):
             network['inputs'][variable_itr]['name'] = _variable_convention_converter.get(variable_item.get('name'))
+
+    # replace 'output' label string with the one used in Athena:
+    for variable_itr, variable_name in enumerate(output_variables_list):
+        if variable_name in list(_output_labeling_convention_converter.keys()):
+            network['outputs'][variable_itr] = _output_labeling_convention_converter.get(variable_name)
+
     return network
 
 def _get_input_variables(network):
@@ -70,6 +83,12 @@ def _get_input_variables(network):
     for variable in network.get('inputs'):
         input_variables.append(variable.get('name'))
     return input_variables
+
+def _get_output_variables(network):
+    output_variables = []
+    for variable in network.get('outputs'):
+        output_variables.append(variable)
+    return output_variables
 
 if __name__ == '__main__':
     _run()

--- a/converters/variables_ntuple2athena.py
+++ b/converters/variables_ntuple2athena.py
@@ -35,6 +35,7 @@ _variable_convention_converter = {
     'eta_abs_uCalib': 'jet_eta',
     'pt_uCalib': 'jet_pt',
     'jf_mass': 'jf_m',
+    'jf_mass_check': 'jf_m_check',
     'jf_efrc': 'jf_efc',
     'jf_sig3': 'jf_sig3d',
     'jf_ntrkv': 'jf_ntrkAtVx',
@@ -42,6 +43,7 @@ _variable_convention_converter = {
     'jf_dR': 'jf_dRFlightDir',
     'sv1_ntkv': 'sv1_ntrkv',
     'sv1_mass': 'sv1_m',
+    'sv1_mass_check': 'sv1_m_check',
     'sv1_efrc': 'sv1_efc',
     'sv1_sig3': 'sv1_sig3d',
     }

--- a/converters/variables_ntuple2athena.py
+++ b/converters/variables_ntuple2athena.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+#
+# Converter from NN configuration with variables used in the training ntuple to the convention used in Athena
+"""
+____________________________________________________________________
+NN configuration file
+
+This is the output of one of the converters, e.g. keras2json.py.
+"""
+
+import argparse
+import json
+
+def _run():
+    """Top level routine"""
+    args = _get_args()
+    with open(args.config_file, 'r') as config_file:
+        nn_config = json.load(config_file)
+
+    nn_config = _update_naming_convention(nn_config)
+
+    with open(args.config_file.replace('.json', '_athena-conventions.json'), 'w') as output_file:
+        json.dump(nn_config, output_file, indent=2)
+    print("Dumped NN configuration file with variable convention as used in Athena to {}.".format(args.config_file.replace('.json', '_athena-conventions.json')))
+
+def _get_args():
+    parser = argparse.ArgumentParser(
+        description="Converter from variables used in the training ntuple to the convention used in Athena",
+        epilog=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument('config_file', help='NN configuration json file')
+    return parser.parse_args()
+
+_variable_convention_converter = {
+    'eta_abs_uCalib': 'jet_eta',
+    'pt_uCalib': 'jet_pt',
+    'jf_mass': 'jf_m',
+    'jf_efrc': 'jf_efc',
+    'jf_sig3': 'jf_sig3d',
+    'jf_ntrkv': 'jf_ntrkAtVx',
+    'jf_n2tv': 'jf_n2t',
+    'jf_dR': 'jf_dRFlightDir',
+    'sv1_ntkv': 'sv1_ntrkv',
+    'sv1_mass': 'sv1_m',
+    'sv1_efrc': 'sv1_efc',
+    'sv1_sig3': 'sv1_sig3d',
+    }
+
+def _update_naming_convention(network):
+    """Update naming convention from the one used during training to the one used in Athena"""
+    input_variable_list = _get_input_variables(network)
+
+    # replace 'default' key string with the one used in Athena:
+    for variable_name in input_variable_list:
+        if variable_name in list(network['defaults'].keys()):
+            if variable_name in list(_variable_convention_converter.keys()):
+                network['defaults'][_variable_convention_converter.get(variable_name)] = network['defaults'].get(variable_name)
+                del network['defaults'][variable_name]
+
+    # replace 'input' 'name' string with the one used in Athena:
+    for variable_itr, variable_item in enumerate(network.get('inputs')):
+        if variable_item.get('name') in list(_variable_convention_converter.keys()):
+            network['inputs'][variable_itr]['name'] = _variable_convention_converter.get(variable_item.get('name'))
+    return network
+
+def _get_input_variables(network):
+    input_variables = []
+    for variable in network.get('inputs'):
+        input_variables.append(variable.get('name'))
+    return input_variables
+
+if __name__ == '__main__':
+    _run()


### PR DESCRIPTION
I adapted the keras2json converter with respect to the output conventions used in Keras version 1.0.0.

In addition, the version number gets saved in the input HDF5 file and a warning is printed in case the Keras output files were generated using another Keras version.