### PR TITLE
'activation' handling in maxout layers

### DIFF
--- a/converters/keras2json.py
+++ b/converters/keras2json.py
@@ -138,6 +138,7 @@ def _get_maxout_layer_parameters(h5, layer_config, n_in):
     assert wt_out == bias_n
     assert wt_in == n_in, '{} != {}'.format(wt_in, n_in)
     assert wt_layers == bias_layers
+    assert 'activation' not in layer_config
 
     sublayers = []
     for nnn in range(weights.shape[0]):
@@ -150,7 +151,7 @@ def _get_maxout_layer_parameters(h5, layer_config, n_in):
         }
         sublayers.append(sublayer)
     return {'sublayers': sublayers, 'architecture': 'maxout',
-            'activation': layer_config['activation']}, wt_out
+            'activation': 'linear'}, wt_out
 
 def _lstm_parameters(h5, layer_config, n_in):
     """LSTM parameter converter"""


### PR DESCRIPTION
Keras does not support the 'activation' key for maxout layers. Instead, an additional layer can be added if so desired e.g. via `model.add(Activation('relu'))`. It should be save though to just take a `'linear'` activation function for maxout layers instead to preserve the current convention.
I checked the assert statement and in case an activation key is wrongly placed in the maxout layer of the architecture file, Python will throw an AssertionError.
(cherry picked from commit 9d7bc5376b91d719433489c2f885f05d9668f439)