### PR TITLE
Fixed bug with flipped matrix order when instantiating Highway, add comparison to Keras

### DIFF
--- a/src/LightweightNeuralNetwork.cxx
+++ b/src/LightweightNeuralNetwork.cxx
@@ -92,8 +92,8 @@ namespace lwt {
   }
 
   // highway layer
-  HighwayLayer::HighwayLayer(const MatrixXd& W_carry, const VectorXd& b_carry, 
-      const MatrixXd& W, const VectorXd& b, Activation activation):
+  HighwayLayer::HighwayLayer(const MatrixXd& W, const VectorXd& b, 
+      const MatrixXd& W_carry, const VectorXd& b_carry, Activation activation):
   _carrylayer(W_carry, b_carry, Activation::SIGMOID), 
   _transformlayer(W, b, activation)
   {
@@ -106,7 +106,7 @@ namespace lwt {
   VectorXd HighwayLayer::compute(const VectorXd& in) const {
     VectorXd carry_output = _carrylayer.compute(in);
     VectorXd transform_output = static_cast<VectorXd>(_transformlayer.compute(in).array() * carry_output.array());
-    return transform_output + static_cast<VectorXd>(1 - carry_output.array() * in.array()); 
+    return transform_output + static_cast<VectorXd>((1 - carry_output.array()) * in.array()); 
   }
 
   // ______________________________________________________________________

--- a/src/lwtnn-test-highway.cxx
+++ b/src/lwtnn-test-highway.cxx
@@ -9,7 +9,6 @@
 #include <string>
 #include <fstream>
 
-
 using Eigen::VectorXd;
 using Eigen::MatrixXd;
 
@@ -29,9 +28,17 @@ int main(int argc, char* argv[]) {
 
 	x << 10.32, 2.32, 1.32, 5.3, 0.01;
 
+	// -- Test Dense:
 	lwt::DenseLayer layer1(W, b, lwt::Activation::RECTIFIED);
+	std::cout << "Predictions from lwtnn Dense:" << std::endl;
 	std::cout << layer1.compute(x) << std::endl;
 
-	lwt::HighwayLayer hw(W, b, 0.17 * W, 3 * b, lwt::Activation::RECTIFIED);
+	// -- Test Highway:
+	lwt::HighwayLayer hw(W, b, 0.17 * W, -3 * b, lwt::Activation::RECTIFIED);
+	std::cout << "Predictions from lwtnn Highway:" << std::endl;
 	std::cout << hw.compute(x) << std::endl;
 }	
+
+// These predictions are to be compared to the ones obtained with Keras and found here:
+// http://nbviewer.jupyter.org/gist/mickypaganini/e997d21682a24e6e8c474af25760afa0
+


### PR DESCRIPTION
I actually noticed that I had my (W, b) and (W_carry, b_carry) switched. I fixed that. 
I also created a gist (http://nbviewer.jupyter.org/gist/mickypaganini/e997d21682a24e6e8c474af25760afa0) where I use the same values as in lwtnn-test-highway.cxx to evaluate the same pattern with Keras. The results now match. You can check this by simply running `./bin/lwtnn-test-highway` and compare the outputs to those in the gist.