### PR TITLE
GRU

### DIFF
--- a/converters/keras2json.py
+++ b/converters/keras2json.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 #
 # Converter from Keras (version 1.0.0) saved NN to JSON
 """
@@ -185,7 +185,7 @@ def _gru_parameters(h5, layer_config, n_in):
             'bias': layers['b_' + gate].flatten().tolist(),
         }
         # TODO: add activation function for some of these gates
-    return {'gru_components': submap, 'architecture': 'lstm',
+    return {'gru_components': submap, 'architecture': 'gru',
             'activation': layer_config['activation'],
             'inner_activation': layer_config['inner_activation']}, n_out
 

--- a/converters/keras2json.py
+++ b/converters/keras2json.py
@@ -28,8 +28,6 @@ The "miscellaneous" object is also optional and can contain (key,
 value) pairs of strings to pass to the application.
 
 """
-_keras_version = '1.0'
-
 
 import argparse
 import warnings
@@ -47,12 +45,12 @@ def _run():
         inputs = json.load(inputs_file)
 
     file_version = inputs.get('keras_version')
-    if  _mvers(file_version) != _mvers(_keras_version):
+    if not file_version.startswith('1.0'):
         warnings.warn(
-            "This converter was developed for Keras version {}. "
+            "This converter was developed for Keras version 1.0.0. "
             "The provided files were generated using version {} and "
             "therefore the conversion might break.".format(
-                _keras_version, file_version))
+                file_version))
 
     with h5py.File(args.hdf5_file, 'r') as h5:
         out_dict = {
@@ -60,12 +58,6 @@ def _run():
         }
         out_dict.update(_parse_inputs(inputs))
     print(json.dumps(out_dict, indent=2))
-
-def _mvers(vstring):
-    """crude versioning, take the first two decimals"""
-    if vstring is None:
-        return 0;
-    return [int(s) for s in vstring.split('.')][:2]
 
 def _get_args():
     parser = argparse.ArgumentParser(

--- a/converters/keras2json.py
+++ b/converters/keras2json.py
@@ -41,7 +41,8 @@ def _run():
     with open(args.variables_file, 'r') as inputs_file:
         inputs = json.load(inputs_file)
 
-    if  inputs.get('keras_version')!="1.0.0":
+    #if inputs.get('keras_version')!="1.0.0":
+    if "1.0" not in inputs.get('keras_version'):
         warnings.warn("This converter was developed for Keras version 1.0.0. \
         The provided files were generated using version {} and therefore \
         the conversion might break.".format(inputs.get('Keras version')))
@@ -236,7 +237,7 @@ _layer_converters = {
     'dense': _get_dense_layer_parameters,
     'maxoutdense': _get_maxout_layer_parameters,
     'lstm': _lstm_parameters,
-    'gru': _gru_parameters,'
+    'gru': _gru_parameters,
     'merge': _get_merge_layer_parameters,
     'activation': _activation_parameters,
     }

--- a/converters/keras2json.py
+++ b/converters/keras2json.py
@@ -167,7 +167,25 @@ def _lstm_parameters(h5, layer_config, n_in):
             'bias': layers['b_' + gate].flatten().tolist(),
         }
         # TODO: add activation function for some of these gates
-    return {'components': submap, 'architecture': 'lstm',
+    return {'lstm_components': submap, 'architecture': 'lstm',
+            'activation': layer_config['activation'],
+            'inner_activation': layer_config['inner_activation']}, n_out
+
+def _gru_parameters(h5, layer_config, n_in):
+    """GRU parameter converter"""
+    layer_group = h5[layer_config['name']]
+    layers = _get_h5_layers(layer_group)
+    n_out = layers['W_h'].shape[1]
+
+    submap = {}
+    for gate in 'zrh':
+        submap[gate] = {
+            'U': layers['U_' + gate].T.flatten().tolist(),
+            'weights': layers['W_' + gate].T.flatten().tolist(),
+            'bias': layers['b_' + gate].flatten().tolist(),
+        }
+        # TODO: add activation function for some of these gates
+    return {'gru_components': submap, 'architecture': 'lstm',
             'activation': layer_config['activation'],
             'inner_activation': layer_config['inner_activation']}, n_out
 
@@ -218,6 +236,7 @@ _layer_converters = {
     'dense': _get_dense_layer_parameters,
     'maxoutdense': _get_maxout_layer_parameters,
     'lstm': _lstm_parameters,
+    'gru': _gru_parameters,'
     'merge': _get_merge_layer_parameters,
     'activation': _activation_parameters,
     }

--- a/include/lwtnn/LightweightRNN.hh
+++ b/include/lwtnn/LightweightRNN.hh
@@ -99,6 +99,45 @@ namespace lwt {
     bool _return_sequences;
   };
 
+  /// gated recurrent unit ///
+  class GRULayer : public IRecurrentLayer
+  {
+  public:
+    GRULayer(Activation activation, Activation inner_activation,
+        MatrixXd W_z, MatrixXd U_z, VectorXd b_z,
+        MatrixXd W_r, MatrixXd U_r, VectorXd b_r,
+        MatrixXd W_h, MatrixXd U_h, VectorXd b_h,
+        bool return_sequences = true);
+
+    virtual ~GRULayer() {};
+    virtual VectorXd step( const VectorXd&);
+    virtual MatrixXd scan( const MatrixXd&);
+
+  private:
+    std::function<double(double)> _activation_fun;
+    std::function<double(double)> _inner_activation_fun;
+
+    MatrixXd _W_z;
+    MatrixXd _U_z;
+    VectorXd _b_z;
+
+    MatrixXd _W_r;
+    MatrixXd _U_r;
+    VectorXd _b_r;
+
+    MatrixXd _W_h;
+    MatrixXd _U_h;
+    VectorXd _b_h;
+
+    //states
+    MatrixXd _h_t;
+    int _time;
+
+    int _n_outputs;
+
+    bool _return_sequences;
+  };
+
   class RecurrentStack
   {
   public:
@@ -111,6 +150,7 @@ namespace lwt {
   private:
     std::vector<IRecurrentLayer*> _layers;
     size_t add_lstm_layers(size_t n_inputs, const LayerConfig&);
+    size_t add_gru_layers(size_t n_inputs, const LayerConfig&);
     size_t add_embedding_layers(size_t n_inputs, const LayerConfig&);
     Stack* _stack;
   };

--- a/include/lwtnn/NNLayerConfig.hh
+++ b/include/lwtnn/NNLayerConfig.hh
@@ -15,9 +15,10 @@
 namespace lwt {
   enum class Activation {NONE, LINEAR, SIGMOID, RECTIFIED, SOFTMAX, TANH,
       HARD_SIGMOID};
-  enum class Architecture {NONE, DENSE, MAXOUT, LSTM, EMBEDDING};
+  enum class Architecture {NONE, DENSE, MAXOUT, LSTM, GRU, EMBEDDING};
   // components (for LSTM, etc)
-  enum class Component {I,O,C,F};
+  enum class LSTMComponent {I, O, C, F};
+  enum class GRUComponent {Z, R, H};
 
   // structure for embedding layers
   struct EmbeddingConfig
@@ -35,11 +36,12 @@ namespace lwt {
     std::vector<double> bias;
     std::vector<double> U;      // TODO: what is this thing called in LSTMs?
     Activation activation;
-    Activation inner_activation; // for LSTMs
+    Activation inner_activation; // for LSTMs and GRUs
 
     // additional info for sublayers
     std::vector<LayerConfig> sublayers;
-    std::map<Component, LayerConfig> components;
+    std::map<LSTMComponent, LayerConfig> lstm_components;
+    std::map<GRUComponent, LayerConfig> gru_components;
     std::vector<EmbeddingConfig> embedding;
 
     // arch flag

--- a/makefile
+++ b/makefile
@@ -25,6 +25,7 @@ vpath %Dict.cxx $(DICT)
 # --- set compiler and flags (roll c options and include paths together)
 CXX          ?= g++
 CXXFLAGS     := -O2 -Wall -fPIC -I$(INC) -g -std=c++11 -pedantic
+CXXFLAGS     += -Wsign-compare
 LIBS         := # blank, more will be added below
 LDFLAGS      := # blank, more will be added below
 # add eigen

--- a/src/LightweightRNN.cxx
+++ b/src/LightweightRNN.cxx
@@ -10,7 +10,6 @@
 
 #include "lwtnn/LightweightRNN.hh"
 
-
 namespace {
   // LSTM component for convenience
   // TODO: consider using this in LSTMLayer
@@ -171,11 +170,10 @@ namespace lwt {
     int tm1 = std::max(0, _time - 1);
     VectorXd h_tm1 = _h_t.col(tm1);
     //VectorXd C_tm1 = _C_t.col(tm1);
-
     VectorXd z  = (_W_z*x_t + _b_z + _U_z*h_tm1).unaryExpr(in_act_fun);
     VectorXd r  = (_W_r*x_t + _b_r + _U_r*h_tm1).unaryExpr(in_act_fun);
     VectorXd hh = (_W_h*x_t + _b_h + _U_h*(r.cwiseProduct(h_tm1))).unaryExpr(act_fun); // r??
-    _h_t.col(_time)  = z.cwiseProduct(h_tm1) + (static_cast<VectorXd>(1) - z).cwiseProduct(hh); // ?
+    _h_t.col(_time)  = z.cwiseProduct(h_tm1) + (VectorXd::Ones(z.size()) - z).cwiseProduct(hh); // ?
 
     return VectorXd( _h_t.col(_time) );
   }

--- a/src/LightweightRNN.cxx
+++ b/src/LightweightRNN.cxx
@@ -175,7 +175,7 @@ namespace lwt {
     VectorXd z  = (_W_z*x_t + _b_z + _U_z*h_tm1).unaryExpr(in_act_fun);
     VectorXd r  = (_W_r*x_t + _b_r + _U_r*h_tm1).unaryExpr(in_act_fun);
     VectorXd hh = (_W_h*x_t + _b_h + _U_h*(r.cwiseProduct(h_tm1))).unaryExpr(act_fun); // r??
-    _h_t.col(_time)  = z.cwiseProduct(h_tm1) + (1-z).cwiseProduct(hh); // ?
+    _h_t.col(_time)  = z.cwiseProduct(h_tm1) + (static_cast<VectorXd>(1) - z).cwiseProduct(hh); // ?
 
     return VectorXd( _h_t.col(_time) );
   }

--- a/src/LightweightRNN.cxx
+++ b/src/LightweightRNN.cxx
@@ -172,8 +172,8 @@ namespace lwt {
     //VectorXd C_tm1 = _C_t.col(tm1);
     VectorXd z  = (_W_z*x_t + _b_z + _U_z*h_tm1).unaryExpr(in_act_fun);
     VectorXd r  = (_W_r*x_t + _b_r + _U_r*h_tm1).unaryExpr(in_act_fun);
-    VectorXd hh = (_W_h*x_t + _b_h + _U_h*(r.cwiseProduct(h_tm1))).unaryExpr(act_fun); // r??
-    _h_t.col(_time)  = z.cwiseProduct(h_tm1) + (VectorXd::Ones(z.size()) - z).cwiseProduct(hh); // ?
+    VectorXd hh = (_W_h*x_t + _b_h + _U_h*(r.cwiseProduct(h_tm1))).unaryExpr(act_fun); 
+    _h_t.col(_time)  = z.cwiseProduct(h_tm1) + (VectorXd::Ones(z.size()) - z).cwiseProduct(hh);
 
     return VectorXd( _h_t.col(_time) );
   }

--- a/src/LightweightRNN.cxx
+++ b/src/LightweightRNN.cxx
@@ -276,7 +276,8 @@ namespace lwt {
     }
     auto outvec = _stack.reduce(inputs);
     ValueMap out;
-    for (size_t iii = 0; iii < outvec.rows(); iii++) {
+    const auto n_rows = static_cast<size_t>(outvec.rows());
+    for (size_t iii = 0; iii < n_rows; iii++) {
       out.emplace(_outputs.at(iii), outvec(iii));
     }
     return out;
@@ -287,7 +288,8 @@ namespace lwt {
   ValueMap LightweightRNN::reduce(const VectorMap& in) const {
     auto outvec = _stack.reduce(_vec_preproc(in));
     ValueMap out;
-    for (size_t iii = 0; iii < outvec.rows(); iii++) {
+    const auto n_rows = static_cast<size_t>(outvec.rows());
+    for (size_t iii = 0; iii < n_rows; iii++) {
       out.emplace(_outputs.at(iii), outvec(iii));
     }
     return out;

--- a/src/lightweight_nn_streamers.cxx
+++ b/src/lightweight_nn_streamers.cxx
@@ -33,6 +33,7 @@ namespace {
     case Architecture::DENSE: return "dense";
     case Architecture::MAXOUT: return "maxout";
     case Architecture::LSTM: return "lstm";
+    case Architecture::GRU: return "gru";
     case Architecture::EMBEDDING: return "embedding";
     }
   }
@@ -40,13 +41,21 @@ namespace {
     out << arch_as_string(ach);
     return out;
   }
-  std::string component_as_string(lwt::Component comp) {
+  std::string component_as_string(lwt::LSTMComponent comp) {
     using namespace lwt;
     switch (comp) {
-    case Component::I: return "i";
-    case Component::O: return "o";
-    case Component::C: return "c";
-    case Component::F: return "f";
+    case LSTMComponent::I: return "i";
+    case LSTMComponent::O: return "o";
+    case LSTMComponent::C: return "c";
+    case LSTMComponent::F: return "f";
+    }
+  }
+  std::string component_as_string(lwt::GRUComponent comp) {
+    using namespace lwt;
+    switch (comp) {
+    case GRUComponent::Z: return "z";
+    case GRUComponent::R: return "r";
+    case GRUComponent::H: return "h"; 
     }
   }
 }
@@ -76,9 +85,17 @@ std::ostream& operator<<(std::ostream& out, const lwt::LayerConfig& cfg){
     }
     out << "]\n";
   }
-  if (cfg.components.size() > 0) {
+  if (cfg.lstm_components.size() > 0) {
     out << "{\n";
-    for (const auto& comp: cfg.components) {
+    for (const auto& comp: cfg.lstm_components) {
+      out << " - component: " << component_as_string(comp.first) << " -\n";
+      out << comp.second << "\n";
+    }
+    out << "}\n";
+  }
+  if (cfg.gru_components.size() > 0) {
+    out << "{\n";
+    for (const auto& comp: cfg.gru_components) {
       out << " - component: " << component_as_string(comp.first) << " -\n";
       out << comp.second << "\n";
     }

--- a/src/lwtnn-test-rnn.cxx
+++ b/src/lwtnn-test-rnn.cxx
@@ -69,12 +69,13 @@ int main(int argc, char* argv[]) {
   lwt::RecurrentStack stack(n_inputs, config.layers);
   lwt::LightweightRNN rnn(config.inputs, config.layers, config.outputs);
   Eigen::VectorXd sum_outputs = Eigen::VectorXd::Zero(stack.n_outputs());
-  size_t n_loops = 10000;
+  size_t n_loops = 1;
   std::cout << "running over " << n_loops << " loops" << std::endl;
   std::cout << "running " << (run_stack ? "fast": "slow") << std::endl;
   for (size_t nnn = 0; nnn < n_loops; nnn++) {
     if (run_stack) {
-      Eigen::MatrixXd test_pattern = Eigen::MatrixXd::Random(n_inputs, 40);
+      Eigen::MatrixXd test_pattern = Eigen::MatrixXd::Random(n_inputs, 2);
+      std::cout << test_pattern << std::endl;
       sum_outputs += stack.reduce(test_pattern);
     } else {
       const auto inputs = get_values_vec(config.inputs);

--- a/src/lwtnn-test-rnn.cxx
+++ b/src/lwtnn-test-rnn.cxx
@@ -21,7 +21,8 @@ std::vector<lwt::ValueMap> get_values(
   const std::vector<lwt::Input>& inputs) {
   Eigen::MatrixXd test_pattern = Eigen::MatrixXd::Random(inputs.size(), 40);
   std::vector<lwt::ValueMap> out;
-  for (size_t iii = 0; iii < test_pattern.cols(); iii++) {
+  const auto n_cols = static_cast<size_t>(test_pattern.cols());
+  for (size_t iii = 0; iii < n_cols; iii++) {
     lwt::ValueMap vals;
     for (size_t jjj = 0; jjj < inputs.size(); jjj++) {
       vals[inputs.at(jjj).name] = test_pattern(jjj, iii);
@@ -36,7 +37,8 @@ lwt::VectorMap get_values_vec(const std::vector<lwt::Input>& inputs) {
   lwt::VectorMap out;
   for (size_t in_num = 0; in_num < inputs.size(); in_num++) {
     std::vector<double> ins;
-    for (size_t iii = 0; iii < test_pattern.cols(); iii++) {
+    const auto n_cols = static_cast<size_t>(test_pattern.cols());
+    for (size_t iii = 0; iii < n_cols; iii++) {
       ins.push_back(test_pattern(in_num, iii));
     }
     out[inputs.at(in_num).name] = std::move(ins);

--- a/src/parse_json.cxx
+++ b/src/parse_json.cxx
@@ -16,6 +16,7 @@ namespace {
   void add_dense_info(LayerConfig& lc, const ptree::value_type& pt);
   void add_maxout_info(LayerConfig& lc, const ptree::value_type& pt);
   void add_lstm_info(LayerConfig& lc, const ptree::value_type& pt);
+  void add_gru_info(LayerConfig& lc, const ptree::value_type& pt);
   void add_embedding_info(LayerConfig& lc, const ptree::value_type& pt);
 }
 
@@ -47,6 +48,8 @@ namespace lwt {
         add_maxout_info(layer, v);
       } else if (arch == Architecture::LSTM) {
         add_lstm_info(layer, v);
+      } else if (arch == Architecture::GRU) {
+        add_gru_info(layer, v);
       } else if (arch == Architecture::EMBEDDING) {
         add_embedding_info(layer, v);
       } else {
@@ -92,6 +95,7 @@ namespace {
     if (str == "dense") return Architecture::DENSE;
     if (str == "maxout") return Architecture::MAXOUT;
     if (str == "lstm") return Architecture::LSTM;
+    if (str == "gru") return Architecture::GRU;
     if (str == "embedding") return Architecture::EMBEDDING;
     throw std::logic_error("architecture " + str + " not recognized");
   }
@@ -134,20 +138,41 @@ namespace {
   }
 
 
-  const std::map<std::string, lwt::Component> lstm_components {
-    {"i", Component::I},
-    {"o", Component::O},
-    {"c", Component::C},
-    {"f", Component::F}
+  const std::map<std::string, lwt::LSTMComponent> lstm_components {
+    {"i", LSTMComponent::I},
+    {"o", LSTMComponent::O},
+    {"c", LSTMComponent::C},
+    {"f", LSTMComponent::F}
   };
 
   void add_lstm_info(LayerConfig& layer, const ptree::value_type& v) {
     using namespace lwt;
-    for (const auto& comp: v.second.get_child("components")) {
+    for (const auto& comp: v.second.get_child("lstm_components")) {
       LayerConfig cfg;
       set_defaults(cfg);
       add_dense_info(cfg, comp);
-      layer.components[lstm_components.at(comp.first)] = cfg;
+      layer.lstm_components[lstm_components.at(comp.first)] = cfg;
+    }
+    layer.activation = get_activation(
+      v.second.get<std::string>("activation"));
+    layer.inner_activation = get_activation(
+      v.second.get<std::string>("inner_activation"));
+  }
+
+
+  const std::map<std::string, lwt::GRUComponent> gru_components {
+    {"z", GRUComponent::Z},
+    {"r", GRUComponent::R},
+    {"h", GRUComponent::H}
+  };
+
+  void add_gru_info(LayerConfig& layer, const ptree::value_type& v) {
+    using namespace lwt;
+    for (const auto& comp: v.second.get_child("gru_components")) {
+      LayerConfig cfg;
+      set_defaults(cfg);
+      add_dense_info(cfg, comp);
+      layer.gru_components[gru_components.at(comp.first)] = cfg;
     }
     layer.activation = get_activation(
       v.second.get<std::string>("activation"));


### PR DESCRIPTION
I implemented GRUs by following the example of LSTMs. Some things might be redundant and could probably be simplified and cleaned up. 

I tested it using `lwtnn-test-rnn.cxx` and that gave me the following output, which matches what I get with Keras, as you can see from this gist: http://nbviewer.jupyter.org/gist/mickypaganini/a9a57e67c130cf77c11605938c6cb5a1

```
[mp744:~/Documents/CERN/Golling/lwtnn] rnn(+11/-10)* 6s ± ./bin/lwtnn-test-rnn nn_config.json 
running over 1 loops
running fast
 -0.999984  -0.866316
 -0.736924  -0.165028
  0.511211   0.373545
-0.0826997   0.177953
 0.0655345   0.860873
 -0.562082   0.692334
 -0.905911  0.0538576
  0.357729   -0.81607
  0.358593   0.307838
  0.869386  -0.168001
 -0.232996   0.402381
 0.0388327   0.820642
  0.661931   0.524396
 -0.930856  -0.475094
 -0.893077  -0.905071
 0.0594004   0.472164
  0.342299  -0.343532
 -0.984604   0.265277
 -0.233169   0.512821
output sum:
0.285286
0.329717
0.161822
0.223176
```

`nn_config.json` was obtained by running `python converters/keras2json.py ../IPNN/RNN.json ../IPNN/variables.json ../IPNN/weights/ip3d-replacement_RNN.h5 > nn_config.json`

`variables.json` is produced here (https://github.com/mickypaganini/IPNN/blob/master/dataprocessing.py#L130) according to the model provided in `keras2json.py`